### PR TITLE
Add options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/
 vendor/bundle/
 .tags
 tmp/
+.idea

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ GET http://staging.exsample.com/hoge/?id=1
 </match>
 ```
 
+## Examples(use support_methods)
+```
+<match http_shadow.exsample>
+  type http_shadow
+  host_hash {
+    "www.example.com": "staging.example.com",
+    "api.example.com": "api-staging.example.com",
+    "blog.ipros.jp": "blog-staging.ipros.jp"
+  }
+  host_key host
+  path_format ${path}
+  method_key method
+  header_hash { "Referer": "${referer}", "User-Agent": "${user_agent}" }
+  support_methods [ "get", "post" ] # It means that only GET and POST are sent. By default all methods are sent.
+</match>
+```
+
 ## note
 
 default GET Request.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ GET http://staging.exsample.com/hoge/?id=1
 </match>
 ```
 
+## Examples(use rate_per_method_hash)
+```
+<match http_shadow.exsample>
+  type http_shadow
+  host_hash {
+    "www.example.com": "staging.example.com",
+    "api.example.com": "api-staging.example.com",
+    "blog.ipros.jp": "blog-staging.ipros.jp"
+  }
+  host_key host
+  path_format ${path}
+  method_key method
+  header_hash { "Referer": "${referer}", "User-Agent": "${user_agent}" }
+  rate_per_method_hash {
+    "get": 30, # This means 30% requests of GET will be sent. Default(when not defined) value is 100.
+    "post": 90
+  }
+</match>
+```
+
 ## note
 
 default GET Request.

--- a/lib/fluent/plugin/out_http_shadow.rb
+++ b/lib/fluent/plugin/out_http_shadow.rb
@@ -86,12 +86,7 @@ module Fluent
         request = get_request(host, record)
         method = request.options[:method]
         next unless SUPPORT_METHODS.include?(method)
-        if @rate_per_method_hash
-          rate_per_method = @rate_per_method_hash[method.to_s] || 100
-          hydra.queue(request) if (Random.rand(100) < rate_per_method)
-        else
-          hydra.queue(request)
-        end
+        hydra.queue(request) if rate_per_method(method)
       end
       hydra.run
     end
@@ -170,6 +165,13 @@ module Fluent
         end
       end
       cookie.join('; ')
+    end
+
+    def rate_per_method(method)
+      return true unless @rate_per_method_hash
+
+      rate_per_method = @rate_per_method_hash[method.to_s] || 100
+      return Random.rand(100) < rate_per_method
     end
   end
 end

--- a/lib/fluent/plugin/out_http_shadow.rb
+++ b/lib/fluent/plugin/out_http_shadow.rb
@@ -2,6 +2,7 @@ module Fluent
   class HttpShadowOutput < Fluent::BufferedOutput
     Fluent::Plugin.register_output('http_shadow', self)
     SUPPORT_PROTOCOLS = ['http', 'https']
+    SUPPORT_METHODS = [:get, :head, :post, :put, :delete]
     PLACEHOLDER_REGEXP = /\$\{([^}]+)\}/
     ERB_REGEXP = "<%=record['" + '\1' + "'] %>"
 
@@ -84,6 +85,7 @@ module Fluent
         next if host.nil?
         request = get_request(host, record)
         method = request.options[:method]
+        next unless SUPPORT_METHODS.include?(method)
         if @rate_per_method_hash
           rate_per_method = @rate_per_method_hash[method.to_s] || 100
           hydra.queue(request) if (Random.rand(100) < rate_per_method)

--- a/test/plugin/test_out_http_shadow.rb
+++ b/test/plugin/test_out_http_shadow.rb
@@ -133,6 +133,24 @@ class HttpShadowOutputTest < Test::Unit::TestCase
     assert_equal header['Cookie'], "cookie1=value1"
   end
 
+  def test_supported?
+    d = create_driver %[
+      host google.com
+      path_format ${path}
+      method_key method
+      path_format ${url}
+      method_key method
+      header_hash { "Referer": "${referer}", "X-Forwarded-For": "${ip_address}" }
+      cookie_hash { "iij-stg1_session": "${session_id}", "___IPROS_UUID_": "${uuid}"}
+      flush_interval 10
+      support_methods [ "get", "post" ]
+    ]
+    d.instance.start
+    assert_true d.instance.send(:supported?, :get)
+    assert_true d.instance.send(:supported?, :post)
+    assert_false d.instance.send(:supported?, :put)
+  end
+
   def test_rate_per_method
     d = create_driver %[
       host google.com

--- a/test/plugin/test_out_http_shadow.rb
+++ b/test/plugin/test_out_http_shadow.rb
@@ -132,6 +132,24 @@ class HttpShadowOutputTest < Test::Unit::TestCase
     assert_equal header['User-Agent'], nil
     assert_equal header['Cookie'], "cookie1=value1"
   end
+
+  def test_rate_per_method
+    d = create_driver %[
+      host google.com
+      path_format ${path}
+      method_key method
+      path_format ${url}
+      method_key method
+      header_hash { "Referer": "${referer}", "X-Forwarded-For": "${ip_address}" }
+      cookie_hash { "iij-stg1_session": "${session_id}", "___IPROS_UUID_": "${uuid}"}
+      flush_interval 10
+      rate_per_method_hash { "get": 100, "post": 0 }
+    ]
+    d.instance.start
+    assert_true d.instance.send(:rate_per_method, :get)
+    assert_false d.instance.send(:rate_per_method, :post)
+    assert_true d.instance.send(:rate_per_method, :put)
+  end
 end
 
 


### PR DESCRIPTION
With reference to [quipper/fluent-plugin-http_shadow](https://github.com/quipper/fluent-plugin-http_shadow), I added two options I want to use with original.

- rate_per_method_hash
  - https://github.com/quipper/fluent-plugin-http_shadow/pull/1/commits/dd3410dfcb5354b5766b7561dd144a265d3a2235
- support_methods
  - https://github.com/quipper/fluent-plugin-http_shadow/pull/2/commits/db85336abed7adaef998c40e3a831a43dbcf1118